### PR TITLE
commsimulator defunct in vegan 2.5-1

### DIFF
--- a/bipartite/NAMESPACE
+++ b/bipartite/NAMESPACE
@@ -19,7 +19,7 @@ import(grDevices)
 import(methods)
 import(stats)
 import(utils)
-importFrom(vegan, cca, commsimulator, designdist, fisher.alpha, fisherfit, nestedchecker, nesteddisc, nestednodf, nestedtemp, treeheight, vegdist)
+importFrom(vegan, cca, designdist, fisher.alpha, fisherfit, nestedchecker, nesteddisc, nestednodf, nestedtemp, treeheight, vegdist)
 importFrom(permute, allPerms) # for use in vegan::nesteddisc
 importFrom(sna, betweenness, closeness, geodist, gplot)
 importFrom(fields, image.plot)

--- a/bipartite/R/nullmodel.r
+++ b/bipartite/R/nullmodel.r
@@ -48,8 +48,10 @@ nullmodel <- function(web, N=1000, method="r2d", ...){
     
     if (m == 4){ #shuffle.web
         if (any(web > 1)) out <- shuffle.web(web, N, ...)
-        if (all(web < 2))
-            out <- replicate(n=N, expr=unname(simulate(vegan::nullmodel(web, method="quasiswap"), nsim=1, ...)[,,1]) , simplify=FALSE) 
+        if (all(web < 2)) {
+            out <- unname(simulate(vegan::nullmodel(web, method="quasiswap"), nsim=N, ...)) 
+            out <- lapply(seq_len(N), function(i) out[,,i])
+        }
     }
 
     if (m == 5){ #mgen

--- a/bipartite/R/nullmodel.r
+++ b/bipartite/R/nullmodel.r
@@ -48,7 +48,8 @@ nullmodel <- function(web, N=1000, method="r2d", ...){
     
     if (m == 4){ #shuffle.web
         if (any(web > 1)) out <- shuffle.web(web, N, ...)
-        if (all(web < 2)) out <- replicate(n=N, expr=unname(commsimulator(web, method="quasiswap", ...)), simplify=FALSE) 
+        if (all(web < 2))
+            out <- replicate(n=N, expr=unname(simulate(vegan::nullmodel(web, method="quasiswap"), nsim=1, ...)[,,1]) , simplify=FALSE) 
     }
 
     if (m == 5){ #mgen

--- a/bipartite/man/discrepancy.Rd
+++ b/bipartite/man/discrepancy.Rd
@@ -17,7 +17,7 @@ discrepancy(mat)
 }
 
 \details{
- Discrepancy is a way to measure the nestedness of a matrix. In a comparative study, Ulrich & Gotelli (2007) showed discrepancy to outperform all other measures and hence recommend its use (together with a fixed-columns, fixed-rows null model, such as implemented in \code{commsimulator} in \pkg{vegan}, see example).
+ Discrepancy is a way to measure the nestedness of a matrix. In a comparative study, Ulrich & Gotelli (2007) showed discrepancy to outperform all other measures and hence recommend its use (together with a fixed-columns, fixed-rows null model, such as implemented in \code{simulate.nullmodel} in \pkg{vegan}, see example).
 
  This function follows the logic laid out by Brualdi & Sanderson (1999), although, admittedly, I find their mathematical description highly confusing. Another implementation is given by the function \code{nesteddisc} in \pkg{vegan}. The reason to write a new function is simple: I wasn't aware of \code{nesteddisc}! (I was sitting on a train and I wanted to use this measure later on, so I put it into a function consulting only the orignal paper. When looking for the swap algorithm to create null models, which I somehow knew to exist in \pkg{vegan}, I stumbled across \code{nesteddisc}. If you are interested in the swap algorithm and come across this help page, let me re-direct you to \code{oecosimu} in \pkg{vegan}.)
  


### PR DESCRIPTION
This PR adapts bipartite to recently released vegan 2.5-1 which finally defuncts commsimulator function. After vegan update, bipartite::nullmodel will fail with method=4 & binary input data, but this PR fixes the issue. This also fixes NAMESPACE and tweaks a manual page for the update.

The fix cannot be made very cleanly, because bipartite::nullmodel function now calls vegan::nullmodel, and this necessarily gives a name clash. I have avoided this by not importing nullmodel from vegan, but instead I use a double colon call to make the difference. I expect that CRAN gatekeepers will accept this because the two packages have functions with exactly identical names.

NB, there will be a message of nullmodel name clash when loading library(bipartite). This probably happens because bipartite Depends on vegan, and this attaches vegan namespace. However, bipartite::nullmodel will mask vegan::nullmodel. To get rid of this message, you should not Depend on vegan, but I have not checked what kind of changes in code and examples that would cause.

If you want to have specifics on vegan versions, this fix requires vegan (>= 2.2) which is pretty old, though (Nov 17, 2014), and probably rare at the wild. 