### PR TITLE
NOS.R returns NAN when the degree of a node is equal to 0

### DIFF
--- a/bipartite/R/NOS.R
+++ b/bipartite/R/NOS.R
@@ -85,7 +85,7 @@ NOS <- function(web, keep.Nij=FALSE, keep.diag=FALSE){
 			else if (S_ij > P_ij){ 
 			  N_ij_out[i,j] <- (S_ij - P_ij)/(min(d_i,d_j) - P_ij)
 			}
-			else if (S_ij < P_ij){
+			else{
 			  if ((d_i + d_j - n) < 0){
 			    N_ij_out[i,j] <- (S_ij - P_ij)/P_ij
 			  }

--- a/bipartite/R/NOS.R
+++ b/bipartite/R/NOS.R
@@ -43,20 +43,22 @@ NOS <- function(web, keep.Nij=FALSE, keep.diag=FALSE){
 				p_ij[k] <- (choose(n, k) *  choose(n - k, d_j - k) * choose(n - d_j, d_i - k)) / (choose(n, d_j) * choose(n, d_i)) * k
 			}
 			P_ij <- sum(p_ij)
-			# compute omega_ij
-			# compute omega_ij (see Strona & Veech, eqns 3-5)
-			if (S_ij == P_ij) omega_ij <- 1
-			if (S_ij > P_ij) omega_ij <- (min(d_i, d_j) - P_ij) / min(d_i, d_j)
-			if (S_ij < P_ij){
-				if ((d_i + d_j - n) < 0){ 
-					omega_ij <- P_ij / min(d_i, d_j)
-				} else {
-					omega_ij <- (P_ij - (d_i + d_j - n))/ min(d_i, d_j)
-				}
+			#Compute N_ij from (Strona & Veech, Eq. 6).  
+			#Instead of computing Omega_ij, simplify Eq. 6 and compute N_ij directly, to avoid division by 0 when min(d_i,d_j)==0
+			if (S_ij == P_ij){
+			  N_ij_in[i,j] <- 0
 			}
-			# finally, compute N_ij:
-	
-			N_ij_in[i, j] <- (S_ij - P_ij) / min(d_i, d_j) * 1/ omega_ij		
+			else if (S_ij > P_ij){ 
+			  N_ij_in[i,j] <- (S_ij - P_ij)/(min(d_i,d_j) - P_ij)
+			}
+			else{
+			  if ((d_i + d_j - n) < 0){
+			    N_ij_in[i,j] <- (S_ij - P_ij)/P_ij
+			  }
+			  else{
+			    N_ij_in[i,j] <- (S_ij - P_ij)/(P_ij - (d_i + d_j - n))
+			  }
+			}
 		}
 	}
 	#if (keep.Nij) out$"N_ij_in" <- N_ij_in
@@ -77,22 +79,21 @@ NOS <- function(web, keep.Nij=FALSE, keep.diag=FALSE){
 				p_ij[k] <- (choose(n, k) *  choose(n - k, d_j - k) * choose(n - d_j, d_i - k)) / (choose(n, d_j) * choose(n, d_i)) * k
 			}
 			P_ij <- sum(p_ij)
-			# compute omega_ij
-			# compute omega_ij (see Strona & Veech, eqns 3-5)
-			if (S_ij == P_ij) omega_ij <- 1
-			if (S_ij > P_ij) omega_ij <- (min(d_i, d_j) - P_ij) / min(d_i, d_j)
-			if (S_ij < P_ij){
-				if ((d_i + d_j - n) < 0){ 
-					omega_ij <- P_ij / min(d_i, d_j)
-				} else {
-					omega_ij <- (P_ij - (d_i + d_j - n))/ min(d_i, d_j)
-				}
+			if (S_ij == P_ij){
+			  N_ij_out[i,j] <- 0
 			}
-			# finally, compute N_ij:
-	
-			N_ij_out[i, j] <- (S_ij - P_ij) / min(d_i, d_j) * 1/ omega_ij		
-			
-			rm(S_ij, P_ij, d_i, d_j, omega_ij, n)
+			else if (S_ij > P_ij){ 
+			  N_ij_out[i,j] <- (S_ij - P_ij)/(min(d_i,d_j) - P_ij)
+			}
+			else if (S_ij < P_ij){
+			  if ((d_i + d_j - n) < 0){
+			    N_ij_out[i,j] <- (S_ij - P_ij)/P_ij
+			  }
+			  else{
+			    N_ij_out[i,j] <- (S_ij - P_ij)/(P_ij - (d_i + d_j - n))
+			  }
+			}
+			rm(S_ij,P_ij,d_i,d_j,n)
 		}
 	}
 	#N_ij_out


### PR DESCRIPTION
This pull request is to update NOS.R to accomodate networks in which the degree of one or more nodes is 0.

Strona and Veench's equations for calculating the average number of node segregation/overlap contains the term min(d_i, d_j) in the denominator.  However, if one of the nodes has degree 0, then min(d_i,d_j) will also be 0, and so the equation will have a division by 0 error.  

For example:
```
> sample_graph <- rbind(c(0,1,0), c(0,3,4),c(0,0,2)) 
> sample_graph    
[,1]    0    1    0 
[2,]    0    3    4 
[3,]    0    0    2 
> NOS(sample_graph) 
$Nbar 
[1] NaN  
$mod 
[1] NA  
$Nbar_higher 
[1] NaN  
$Nbar_lower
[1] 0.3333333  
$mod_lower 
[1] 1.154701  
$mod_higher 
[1] NA  
```

Instead of computing both omega_ij and (S_ij - P_ij)/min(d_i,d_j) directly, we can cancel out the min(d_i, d_j) terms and avoid any divisions by 0.
