### PR TITLE
Update betalinkr.R

### DIFF
--- a/bipartite/R/betalinkr.R
+++ b/bipartite/R/betalinkr.R
@@ -13,8 +13,8 @@ betalinkr <- function(webarray, index = "bray", binary=TRUE, partitioning="commo
   if (proportions){
     if (binary){warning("standardizing to proportions for binary index; do you really want to do this?!?")}
     array.of.sums <- webarray
-    array.of.sums[,,1] <- sum(webarray[,,1])
-    array.of.sums[,,2] <- sum(webarray[,,2])
+    array.of.sums[,,1] <- ifelse(sum(webarray[,,1])==0, 1, sum(webarray[,,1]))   # avoid division by zero for empty webs
+    array.of.sums[,,2] <- ifelse(sum(webarray[,,2])==0, 1, sum(webarray[,,2]))   # avoid division by zero for empty webs
     webarray <- webarray / array.of.sums
   }
 
@@ -42,7 +42,7 @@ betalinkr <- function(webarray, index = "bray", binary=TRUE, partitioning="commo
     # now ensuring a single entry per species also in named foodwebs (adding ingoing and outgoing links, instead of counting them separately)
   specmx.lower <- apply(webarray, c(3,1), sum)
   specmx.higher <- apply(webarray, c(3,2), sum)
-  specmx.higher.unique <- specmx.higher[, !(colnames(specmx.higher) %in% colnames(specmx.lower))]
+  specmx.higher.unique <- specmx.higher[, !(colnames(specmx.higher) %in% colnames(specmx.lower)), drop=F]  # add drop=F so that one-column matrices don´t loose their dimension
   if (is.null(colnames(specmx.higher))) {specmx.higher.unique <- specmx.higher}  # if no species names are given, assuming bipartite webs
   specmx.all <- cbind(specmx.lower, specmx.higher.unique)  # e.g. sites X (plants, pollinators); 
   duplicolnames <- setdiff(colnames(specmx.higher), colnames(specmx.higher.unique))


### PR DESCRIPTION
two small changes: 1. Now standardization to proportions also works for empty webs as division by zero is avoided. 2. specmx.higher.unique can be assessed for 1-link-webs as setting drop=FALSE keeps the dimensions of the matrix.